### PR TITLE
SWAP-1154 Only show instruments assigned to the use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,13 +66,14 @@ async function bootstrap() {
             ).toString('base64');
 
             request.http?.headers.set('x-auth-jwt-payload', encodedPayload);
-          } else {
-            if (context.authToken) {
-              request.http?.headers.set(
-                'authorization',
-                `Bearer ${context.authToken}`
-              );
-            }
+          }
+
+          // include the token as we may call the core directly from the scheduler
+          if (context.authToken) {
+            request.http?.headers.set(
+              'authorization',
+              `Bearer ${context.authToken}`
+            );
           }
         },
       });


### PR DESCRIPTION
## Description

Pass on the JWT token in every case if we have one, as we now call user office core when we checking instrument scientist read/write permissions.

## Motivation and Context

Required by the scheduler, as we need to check if a user has access to a instrument / proposal.

## How Has This Been Tested

It relay on e2e tests.

## Fixes

https://jira.esss.lu.se/browse/SWAP-1154

## Changes

Pass on the JWT token in every case if we have one.

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
