### PR TITLE
chore: exclude pushing to dockerhub if dependabot is creating the PR

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,6 +43,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # Don't run if dependabot created the PR
+    if: github.actor != 'dependabot[bot]'
     needs: test
 
     steps:
@@ -62,12 +64,16 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
+        # Don't login if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
+        # Don't login if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -80,6 +86,8 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v2
+        # Don't build and push the image if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         with:
           push: true
           tags: |


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Update test-build action to exclude login and push to docker hub if dependabot is creating the PRs