### PR TITLE
chore: Build but not push images from dependabot

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,8 +43,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # Don't run if dependabot created the PR
-    if: github.actor != 'dependabot[bot]'
     needs: test
 
     steps:
@@ -77,11 +75,9 @@ jobs:
         run: echo "Extracted branch ${{ github.head_ref }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v2
-        # Don't build and push the image if dependabot is creating the PR
-        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
+        uses: docker/build-push-action@v4
         with:
-          push: true
+          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
           tags: ghcr.io/userofficeproject/user-office-gateway:${{ github.head_ref }}
           cache-from: type=local,src=/tmp/.buildx-layer-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-layer-cache


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Let it build to test the docker build operation but do not push and login to the registry