### PR TITLE
refactor(deprecation warning): move away from graphql-playground as it is deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@apollo/gateway": "^2.5.6",
         "@apollo/server": "^4.9.4",
-        "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
         "@user-office-software/duo-logger": "^2.0.2",
         "dotenv": "^16.3.1",
         "graphql": "^16.8.1",
@@ -231,21 +230,6 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
-    "node_modules/@apollo/server-plugin-landing-page-graphql-playground": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-      "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-      "deprecated": "The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.",
-      "dependencies": {
-        "@apollographql/graphql-playground-html": "1.6.29"
-      },
-      "engines": {
-        "node": ">=14.0"
-      },
-      "peerDependencies": {
-        "@apollo/server": "^4.0.0"
-      }
-    },
     "node_modules/@apollo/usage-reporting-protobuf": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
@@ -385,14 +369,6 @@
       "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1956,11 +1932,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6611,26 +6582,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -6821,14 +6772,6 @@
         "@apollo/utils.logger": "^2.0.0"
       }
     },
-    "@apollo/server-plugin-landing-page-graphql-playground": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-      "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-      "requires": {
-        "@apollographql/graphql-playground-html": "1.6.29"
-      }
-    },
     "@apollo/usage-reporting-protobuf": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
@@ -6919,14 +6862,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
       "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ=="
-    },
-    "@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "requires": {
-        "xss": "^1.0.8"
-      }
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -8109,11 +8044,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -11422,22 +11352,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@apollo/gateway": "^2.5.6",
     "@apollo/server": "^4.9.4",
-    "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
     "@user-office-software/duo-logger": "^2.0.2",
     "dotenv": "^16.3.1",
     "graphql": "^16.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,11 @@ import {
 } from '@apollo/gateway';
 import { ApolloServer, BaseContext, ContextFunction } from '@apollo/server';
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled';
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
 import {
   StandaloneServerContextFunctionArgument,
   startStandaloneServer,
 } from '@apollo/server/standalone';
-import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import { logger } from '@user-office-software/duo-logger';
 
 import AuthProvider, {
@@ -124,7 +124,10 @@ async function bootstrap() {
     plugins: [
       process.env.NODE_ENV === 'production'
         ? ApolloServerPluginLandingPageDisabled()
-        : ApolloServerPluginLandingPageGraphQLPlayground(),
+        : ApolloServerPluginLandingPageLocalDefault({
+            footer: false,
+            embed: { initialState: { pollForSchemaUpdates: false } },
+          }),
     ],
   });
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR aims to switch from graphql playground to Apollo Server's default Explorer

## Motivation and Context

The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.

## How Has This Been Tested

- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-3605

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
