### PR TITLE
chore: trigger the ESS deployment pipeline only for staging branch

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -45,6 +45,7 @@ jobs:
           tags: ghcr.io/userofficeproject/user-office-gateway:${{ steps.extract_branch.outputs.branch }}
 
       - name: Trigger pipeline
+        if: ${{ steps.extract_branch.outputs.branch == 'staging' }}
         uses: swapActions/trigger-useroffice-deployment@v1
         with:
           repository: ${{ github.repository }}


### PR DESCRIPTION
Our new development environment does not need to be triggered when a new version is released.