### PR TITLE
chore: node 22 upgrade

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -18,16 +18,16 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: 22.x-cache-node-modules
         with:
@@ -42,16 +42,16 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache app docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-layer-cache
           key: ${{ runner.os }}-buildx-${{ github.head_ref }}-${{ github.sha }}
@@ -62,7 +62,7 @@ jobs:
       - name: Login to GitHub Container Registry
         # Don't login if dependabot is creating the PR
         if: ${{ !startsWith(github.head_ref, 'dependabot') }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
         run: echo "Extracted branch ${{ github.head_ref }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: ${{ !startsWith(github.head_ref, 'dependabot') }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: 22.x
 
       - name: Cache node_modules
         uses: actions/cache@v2
         env:
-          cache-name: 18.x-cache-node-modules
+          cache-name: 22.x-cache-node-modules
         with:
           path: ~/.npm
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine AS build-stage
+FROM node:22.14.0-alpine AS build-stage
 
 USER node
 
@@ -14,7 +14,7 @@ COPY --chown=node:node . .
 
 RUN npm run build
 
-FROM node:18.17.1-alpine
+FROM node:22.14.0-alpine
 
 USER node
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "type-graphql": "^2.0.0-rc.2"
       },
       "devDependencies": {
+        "@types/node": "^22.13.10",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.1",
@@ -33,8 +34,8 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -807,9 +808,13 @@
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -6141,6 +6146,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "type-graphql": "^2.0.0-rc.2"
   },
   "devDependencies": {
+    "@types/node": "^22.13.10",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.57.1",
@@ -41,7 +42,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.9.2",
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Description
Upgrades Node.js from 18.x to 22.x across the project, updating all relevant configuration files.

## Motivation and Context
Node 18 reaches end-of-life after April 2025. This upgrade leverages new features, improvements, and security patches to boost performance and security.

## Changes
- Updated Node.js version in GitHub workflows and Dockerfiles.
- Upgraded @types/node in package-lock.json and package.json.
- Adjusted npm and Node.js version requirements in package.json engines.