### PR TITLE
chore: remove service health check due to race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,15 +142,6 @@ async function bootstrap() {
     listen: { port },
   });
   logger.logInfo(`Apollo Gateway ready at ${url}`, {});
-
-  // because of an unfortunate bug/behavior if polling is enabled (or not?) and the schema isn't available
-  // it will stop trying to resolve the schema
-  // as a workaround explicitly check the status and throw error if the schema is not available
-  await gateway.serviceHealthCheck().catch(async (err) => {
-    await server.stop();
-
-    return Promise.reject(err);
-  });
 }
 
 let exits = 0;


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

In addition to starting the gateway, there is a health check. Due to race condition, sometimes the health check fails stopping the overlying container from starting. Since the health check is an integral part of gateway start, the health check can be safely removed. 
<!--- Describe your changes in detail -->

## Motivation and Context

Gateway Container start optimisation
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
